### PR TITLE
Gears support

### DIFF
--- a/Garmin.Connect.Tests/Integrations/GearsTests.cs
+++ b/Garmin.Connect.Tests/Integrations/GearsTests.cs
@@ -1,0 +1,50 @@
+using System;
+using System.Threading.Tasks;
+
+using Garmin.Connect.Models;
+
+using Xunit;
+
+namespace Garmin.Connect.Tests.Integrations;
+
+public class GearsTests
+{
+    private readonly Lazy<Task<GarminActivity[]>> _lazyActivities =
+        new(() => LazyClient.Garmin.Value.GetActivities(1, 1));
+
+    private readonly IGarminConnectClient _garmin;
+
+    public GearsTests ()
+    {
+        _garmin = LazyClient.Garmin.Value;
+    }
+
+    [Fact]
+    public async Task GetGearTypes_NotNull ()
+    {
+        var gearTypes = await _garmin.GetGearTypes();
+
+        Assert.NotNull(gearTypes);
+        Assert.NotEmpty(gearTypes);
+    }
+
+    [Fact]
+    public async Task GetUserGears_NotNull ()
+    {
+        var garminActivities = await _lazyActivities.Value;
+        var userGears = await _garmin.GetUserGears(garminActivities[0].OwnerId);
+
+        Assert.NotNull(userGears);
+        Assert.NotEmpty(userGears);
+    }
+
+    [Fact]
+    public async Task GetActivityGears_NotNull ()
+    {
+        var garminActivities = await _lazyActivities.Value;
+        var activityGears = await _garmin.GetActivityGears(garminActivities[0].ActivityId);
+
+        Assert.NotNull(activityGears);
+        Assert.NotEmpty(activityGears);
+    }
+}

--- a/Garmin.Connect.Tests/Integrations/GearsTests.cs
+++ b/Garmin.Connect.Tests/Integrations/GearsTests.cs
@@ -14,13 +14,13 @@ public class GearsTests
 
     private readonly IGarminConnectClient _garmin;
 
-    public GearsTests ()
+    public GearsTests()
     {
         _garmin = LazyClient.Garmin.Value;
     }
 
     [Fact]
-    public async Task GetGearTypes_NotNull ()
+    public async Task GetGearTypes_NotNull()
     {
         var gearTypes = await _garmin.GetGearTypes();
 
@@ -29,7 +29,7 @@ public class GearsTests
     }
 
     [Fact]
-    public async Task GetUserGears_NotNull ()
+    public async Task GetUserGears_NotNull()
     {
         var garminActivities = await _lazyActivities.Value;
         var userGears = await _garmin.GetUserGears(garminActivities[0].OwnerId);
@@ -39,7 +39,7 @@ public class GearsTests
     }
 
     [Fact]
-    public async Task GetActivityGears_NotNull ()
+    public async Task GetActivityGears_NotNull()
     {
         var garminActivities = await _lazyActivities.Value;
         var activityGears = await _garmin.GetActivityGears(garminActivities[0].ActivityId);

--- a/Garmin.Connect/Converters/DateTimeConverter.cs
+++ b/Garmin.Connect/Converters/DateTimeConverter.cs
@@ -10,10 +10,15 @@ namespace Garmin.Connect.Converters;
 internal class DateTimeConverter : JsonConverter<DateTime>
 {
     private const string Format = "yyyy-MM-dd HH:mm:ss";
+    private const string Format2nd = "yyyy-MM-dd\\THH:mm:ss.f";
+    private readonly static string[] Formats = new string[] { Format, Format2nd };
 
     public override DateTime Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
     {
-        return DateTime.ParseExact(GetRawString(reader), Format, CultureInfo.InvariantCulture);
+        string dateTimeString = GetRawString( reader );
+        return dateTimeString == "null"
+          ? DateTime.MinValue
+          : DateTime.ParseExact( dateTimeString, Formats, CultureInfo.InvariantCulture, DateTimeStyles.None );
     }
 
     public override void Write(Utf8JsonWriter writer, DateTime value, JsonSerializerOptions options)

--- a/Garmin.Connect/Converters/DateTimeConverter.cs
+++ b/Garmin.Connect/Converters/DateTimeConverter.cs
@@ -15,10 +15,7 @@ internal class DateTimeConverter : JsonConverter<DateTime>
 
     public override DateTime Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
     {
-        string dateTimeString = GetRawString( reader );
-        return dateTimeString == "null"
-          ? DateTime.MinValue
-          : DateTime.ParseExact( dateTimeString, Formats, CultureInfo.InvariantCulture, DateTimeStyles.None );
+        return DateTime.ParseExact( GetRawString( reader ), Formats, CultureInfo.InvariantCulture, DateTimeStyles.None );
     }
 
     public override void Write(Utf8JsonWriter writer, DateTime value, JsonSerializerOptions options)

--- a/Garmin.Connect/GarminConnectClient.cs
+++ b/Garmin.Connect/GarminConnectClient.cs
@@ -29,7 +29,7 @@ public class GarminConnectClient : IGarminConnectClient
     private const string DeviceServiceUrl = "/proxy/device-service/deviceservice/";
     private const string GearUrl = "/proxy/gear-service/gear/";
 
-    public GarminConnectClient (GarminConnectContext context)
+    public GarminConnectClient(GarminConnectContext context)
     {
         _context = context;
     }
@@ -64,7 +64,7 @@ public class GarminConnectClient : IGarminConnectClient
 
         // mimicking the behavior of the web interface that fetches 20 activities at a time
         // and automatically loads more on scroll
-        if (!string.IsNullOrEmpty(activityType))
+        if ( !string.IsNullOrEmpty(activityType) )
         {
             activitySlug = "&activityType=" + activityType;
         }
@@ -76,14 +76,14 @@ public class GarminConnectClient : IGarminConnectClient
         var result = new List<GarminActivity>();
 
         var returnData = true;
-        while (returnData)
+        while ( returnData )
         {
             var activitiesUrl =
                 $"{ActivitiesUrl}?startDate={startDate:yyyy-MM-dd}&endDate={endDate:yyyy-MM-dd}&start={start}&limit={limit}{activitySlug}";
 
             var activities = await _context.GetAndDeserialize<GarminActivity[]>(activitiesUrl);
 
-            if (activities.Any())
+            if ( activities.Any() )
             {
                 result.AddRange(activities);
                 start += limit;
@@ -99,7 +99,7 @@ public class GarminConnectClient : IGarminConnectClient
 
     public async Task<GarminUserPreferences> GetPreferences()
     {
-        if (_context.Preferences is null)
+        if ( _context.Preferences is null )
         {
             await _context.ReLoginIfExpired();
         }
@@ -109,7 +109,7 @@ public class GarminConnectClient : IGarminConnectClient
 
     public async Task<GarminSocialProfile> GetSocialProfile()
     {
-        if (_context.Profile is null)
+        if ( _context.Profile is null )
         {
             await _context.ReLoginIfExpired();
         }
@@ -251,7 +251,7 @@ public class GarminConnectClient : IGarminConnectClient
                 $"{CsvDownloadUrl}{activityId}"
             }
         };
-        if (!urls.ContainsKey(format))
+        if ( !urls.ContainsKey(format) )
         {
             throw new ArgumentException($"Unexpected value {format} for dl_fmt");
         }
@@ -263,24 +263,24 @@ public class GarminConnectClient : IGarminConnectClient
         return await response.Content.ReadAsByteArrayAsync();
     }
 
-    public Task<GarminGearType[]> GetGearTypes ()
+    public Task<GarminGearType[]> GetGearTypes()
     {
         string gearTypesUrl = $"{GearUrl}types";
 
-        return _context.GetAndDeserialize<GarminGearType[]>( gearTypesUrl );
+        return _context.GetAndDeserialize<GarminGearType[]>(gearTypesUrl);
     }
 
-    public Task<GarminGear[]> GetUserGears ( long userId )
+    public Task<GarminGear[]> GetUserGears(long userId)
     {
         string userGearsUrl = $"{GearUrl}filterGear?userProfilePk={userId}";
 
-        return _context.GetAndDeserialize<GarminGear[]>( userGearsUrl );
+        return _context.GetAndDeserialize<GarminGear[]>(userGearsUrl);
     }
 
-    public Task<GarminGear[]> GetActivityGears ( long activityId )
+    public Task<GarminGear[]> GetActivityGears(long activityId)
     {
         string activityGearsUrl = $"{GearUrl}filterGear?activityId={activityId}";
 
-        return _context.GetAndDeserialize<GarminGear[]>( activityGearsUrl );
+        return _context.GetAndDeserialize<GarminGear[]>(activityGearsUrl);
     }
 }

--- a/Garmin.Connect/GarminConnectClient.cs
+++ b/Garmin.Connect/GarminConnectClient.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+
 using Garmin.Connect.Models;
 
 namespace Garmin.Connect;
@@ -64,7 +65,7 @@ public class GarminConnectClient : IGarminConnectClient
 
         // mimicking the behavior of the web interface that fetches 20 activities at a time
         // and automatically loads more on scroll
-        if ( !string.IsNullOrEmpty(activityType) )
+        if (!string.IsNullOrEmpty(activityType))
         {
             activitySlug = "&activityType=" + activityType;
         }
@@ -76,14 +77,14 @@ public class GarminConnectClient : IGarminConnectClient
         var result = new List<GarminActivity>();
 
         var returnData = true;
-        while ( returnData )
+        while (returnData)
         {
             var activitiesUrl =
                 $"{ActivitiesUrl}?startDate={startDate:yyyy-MM-dd}&endDate={endDate:yyyy-MM-dd}&start={start}&limit={limit}{activitySlug}";
 
             var activities = await _context.GetAndDeserialize<GarminActivity[]>(activitiesUrl);
 
-            if ( activities.Any() )
+            if (activities.Any())
             {
                 result.AddRange(activities);
                 start += limit;
@@ -99,7 +100,7 @@ public class GarminConnectClient : IGarminConnectClient
 
     public async Task<GarminUserPreferences> GetPreferences()
     {
-        if ( _context.Preferences is null )
+        if (_context.Preferences is null)
         {
             await _context.ReLoginIfExpired();
         }
@@ -109,7 +110,7 @@ public class GarminConnectClient : IGarminConnectClient
 
     public async Task<GarminSocialProfile> GetSocialProfile()
     {
-        if ( _context.Profile is null )
+        if (_context.Profile is null)
         {
             await _context.ReLoginIfExpired();
         }
@@ -251,7 +252,7 @@ public class GarminConnectClient : IGarminConnectClient
                 $"{CsvDownloadUrl}{activityId}"
             }
         };
-        if ( !urls.ContainsKey(format) )
+        if (!urls.ContainsKey(format))
         {
             throw new ArgumentException($"Unexpected value {format} for dl_fmt");
         }

--- a/Garmin.Connect/GarminConnectClient.cs
+++ b/Garmin.Connect/GarminConnectClient.cs
@@ -27,8 +27,9 @@ public class GarminConnectClient : IGarminConnectClient
     private const string CsvDownloadUrl = "/proxy/download-service/export/csv/activity/";
     private const string DeviceListUrl = "/proxy/device-service/deviceregistration/devices";
     private const string DeviceServiceUrl = "/proxy/device-service/deviceservice/";
+    private const string GearUrl = "/proxy/gear-service/gear/";
 
-    public GarminConnectClient(GarminConnectContext context)
+    public GarminConnectClient (GarminConnectContext context)
     {
         _context = context;
     }
@@ -260,5 +261,26 @@ public class GarminConnectClient : IGarminConnectClient
         var response = await _context.MakeHttpGet(url);
 
         return await response.Content.ReadAsByteArrayAsync();
+    }
+
+    public Task<GarminGearType[]> GetGearTypes ()
+    {
+        string gearTypesUrl = $"{GearUrl}types";
+
+        return _context.GetAndDeserialize<GarminGearType[]>( gearTypesUrl );
+    }
+
+    public Task<GarminGear[]> GetUserGears ( long userId )
+    {
+        string userGearsUrl = $"{GearUrl}filterGear?userProfilePk={userId}";
+
+        return _context.GetAndDeserialize<GarminGear[]>( userGearsUrl );
+    }
+
+    public Task<GarminGear[]> GetActivityGears ( long activityId )
+    {
+        string activityGearsUrl = $"{GearUrl}filterGear?activityId={activityId}";
+
+        return _context.GetAndDeserialize<GarminGear[]>( activityGearsUrl );
     }
 }

--- a/Garmin.Connect/IGarminConnectClient.cs
+++ b/Garmin.Connect/IGarminConnectClient.cs
@@ -7,107 +7,107 @@ namespace Garmin.Connect;
 
 public interface IGarminConnectClient
 {
-    Task<GarminUserPreferences> GetPreferences ();
+    Task<GarminUserPreferences> GetPreferences();
 
-    Task<GarminSocialProfile> GetSocialProfile ();
+    Task<GarminSocialProfile> GetSocialProfile();
 
     /// <summary>
     /// Fetch user settings
     /// </summary>
-    Task<GarminUserSettings> GetUserSettings ();
+    Task<GarminUserSettings> GetUserSettings();
 
     /// <summary>
     /// Fetch available activity data
     /// </summary>
-    Task<GarminStats> GetUserSummary (DateTime date);
+    Task<GarminStats> GetUserSummary(DateTime date);
 
     /// <summary>
     /// Fetch available sleep data
     /// </summary>
-    Task<GarminSleepData> GetWellnessSleepData (DateTime date);
+    Task<GarminSleepData> GetWellnessSleepData(DateTime date);
 
     /// <summary>
     /// Fetch available heart rates data
     /// </summary>
-    Task<GarminHr> GetWellnessHeartRates (DateTime date);
+    Task<GarminHr> GetWellnessHeartRates(DateTime date);
 
     /// <summary>
     /// Fetch available steps data
     /// </summary>
-    Task<GarminStepsData[]> GetWellnessStepsData (DateTime date);
+    Task<GarminStepsData[]> GetWellnessStepsData(DateTime date);
 
     /// <summary>
     /// Fetch available hydration data
     /// </summary>
-    Task<GarminHydrationData> GetHydrationData (DateTime date);
+    Task<GarminHydrationData> GetHydrationData(DateTime date);
 
     /// <summary>
     /// Fetch available body composition data (only for date)
     /// </summary>
-    Task<GarminBodyComposition> GetBodyComposition (DateTime startDate, DateTime endDate);
+    Task<GarminBodyComposition> GetBodyComposition(DateTime startDate, DateTime endDate);
 
     /// <summary>
     /// Fetch personal records by owner display name
     /// </summary>
-    Task<GarminPersonalRecord[]> GetPersonalRecord (string ownerDisplayName);
+    Task<GarminPersonalRecord[]> GetPersonalRecord(string ownerDisplayName);
 
     /// <summary>
     /// Fetch device last used
     /// </summary>
-    Task<GarminDeviceLastUsed> GetDeviceLastUsed ();
+    Task<GarminDeviceLastUsed> GetDeviceLastUsed();
 
     /// <summary>
     /// Fetch device settings for current device
     /// </summary>
-    Task<GarminDeviceSettings> GetDeviceSettings (long deviceId);
+    Task<GarminDeviceSettings> GetDeviceSettings(long deviceId);
 
     /// <summary>
     /// Fetch available devices for the current account
     /// </summary>
-    Task<GarminDevice[]> GetDevices ();
+    Task<GarminDevice[]> GetDevices();
 
     /// <summary>
     /// Fetch activity split summaries
     /// </summary>
-    Task<GarminSplitSummary> GetActivitySplitSummaries (long activityId);
+    Task<GarminSplitSummary> GetActivitySplitSummaries(long activityId);
 
     /// <summary>
     /// Fetch activity details
     /// </summary>
-    Task<GarminActivityDetails> GetActivityDetails (long activityId, int maxChartSize = 2000,
+    Task<GarminActivityDetails> GetActivityDetails(long activityId, int maxChartSize = 2000,
         int maxPolylineSize = 4000);
 
     /// <summary>
     /// Fetch activity excercise sets
     /// </summary>
-    Task<GarminExcerciseSets> GetActivityExcerciseSets (long activityId);
+    Task<GarminExcerciseSets> GetActivityExcerciseSets(long activityId);
 
     /// <summary>
     /// Fetch activity weather
     /// </summary>
-    Task<GarminActivityWeather> GetActivityWeather (long activityId);
+    Task<GarminActivityWeather> GetActivityWeather(long activityId);
 
     /// <summary>
     ///  Fetch activity splits
     /// </summary>
-    Task<GarminActivitySplits> GetActivitySplits (long activityId);
+    Task<GarminActivitySplits> GetActivitySplits(long activityId);
 
     /// <summary>
     /// Fetch activity HR in timezones
     /// </summary>
-    Task<GarminHrTimeInZones[]> GetActivityHrInTimezones (long activityId);
+    Task<GarminHrTimeInZones[]> GetActivityHrInTimezones(long activityId);
 
     /// <summary>
     /// Downloads activity in requested format and returns the raw bytes. For
     /// "Original" will return the zip file content, up to user to extract it.
     /// "CSV" will return a csv of the splits.
     /// </summary>
-    Task<byte[]> DownloadActivity (long activityId, ActivityDownloadFormat format = ActivityDownloadFormat.TCX);
+    Task<byte[]> DownloadActivity(long activityId, ActivityDownloadFormat format = ActivityDownloadFormat.TCX);
 
     /// <summary>
     /// Fetch available activities
     /// </summary>
-    Task<GarminActivity[]> GetActivities (int start, int limit);
+    Task<GarminActivity[]> GetActivities(int start, int limit);
 
     /// <summary>
     /// Fetch available activities between specific dates
@@ -118,20 +118,20 @@ public interface IGarminConnectClient
     /// (Optional) Type of activity you are searching
     /// Possible values are [cycling, running, swimming, multi_sport, fitness_equipment, hiking, walking, other]
     /// </param>
-    Task<GarminActivity[]> GetActivitiesByDate (DateTime startDate, DateTime endDate, string activityType = "");
+    Task<GarminActivity[]> GetActivitiesByDate(DateTime startDate, DateTime endDate, string activityType = "");
 
     /// <summary>
     /// Fetch gear types.
     /// </summary>
-    Task<GarminGearType[]> GetGearTypes ();
+    Task<GarminGearType[]> GetGearTypes();
 
     /// <summary>
     /// Fetch user gears.
     /// </summary>
-    Task<GarminGear[]> GetUserGears (long userId);
+    Task<GarminGear[]> GetUserGears(long userId);
 
     /// <summary>
     /// Fetch activity gears.
     /// </summary>
-    Task<GarminGear[]> GetActivityGears (long activityId);
+    Task<GarminGear[]> GetActivityGears(long activityId);
 }

--- a/Garmin.Connect/IGarminConnectClient.cs
+++ b/Garmin.Connect/IGarminConnectClient.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Threading.Tasks;
+
 using Garmin.Connect.Models;
 
 namespace Garmin.Connect;
@@ -18,37 +19,37 @@ public interface IGarminConnectClient
     /// <summary>
     /// Fetch available activity data
     /// </summary>
-    Task<GarminStats> GetUserSummary ( DateTime date );
+    Task<GarminStats> GetUserSummary (DateTime date);
 
     /// <summary>
     /// Fetch available sleep data
     /// </summary>
-    Task<GarminSleepData> GetWellnessSleepData ( DateTime date );
+    Task<GarminSleepData> GetWellnessSleepData (DateTime date);
 
     /// <summary>
     /// Fetch available heart rates data
     /// </summary>
-    Task<GarminHr> GetWellnessHeartRates ( DateTime date );
+    Task<GarminHr> GetWellnessHeartRates (DateTime date);
 
     /// <summary>
     /// Fetch available steps data
     /// </summary>
-    Task<GarminStepsData[]> GetWellnessStepsData ( DateTime date );
+    Task<GarminStepsData[]> GetWellnessStepsData (DateTime date);
 
     /// <summary>
     /// Fetch available hydration data
     /// </summary>
-    Task<GarminHydrationData> GetHydrationData ( DateTime date );
+    Task<GarminHydrationData> GetHydrationData (DateTime date);
 
     /// <summary>
     /// Fetch available body composition data (only for date)
     /// </summary>
-    Task<GarminBodyComposition> GetBodyComposition ( DateTime startDate, DateTime endDate );
+    Task<GarminBodyComposition> GetBodyComposition (DateTime startDate, DateTime endDate);
 
     /// <summary>
     /// Fetch personal records by owner display name
     /// </summary>
-    Task<GarminPersonalRecord[]> GetPersonalRecord ( string ownerDisplayName );
+    Task<GarminPersonalRecord[]> GetPersonalRecord (string ownerDisplayName);
 
     /// <summary>
     /// Fetch device last used
@@ -58,7 +59,7 @@ public interface IGarminConnectClient
     /// <summary>
     /// Fetch device settings for current device
     /// </summary>
-    Task<GarminDeviceSettings> GetDeviceSettings ( long deviceId );
+    Task<GarminDeviceSettings> GetDeviceSettings (long deviceId);
 
     /// <summary>
     /// Fetch available devices for the current account
@@ -68,45 +69,45 @@ public interface IGarminConnectClient
     /// <summary>
     /// Fetch activity split summaries
     /// </summary>
-    Task<GarminSplitSummary> GetActivitySplitSummaries ( long activityId );
+    Task<GarminSplitSummary> GetActivitySplitSummaries (long activityId);
 
     /// <summary>
     /// Fetch activity details
     /// </summary>
-    Task<GarminActivityDetails> GetActivityDetails ( long activityId, int maxChartSize = 2000,
-        int maxPolylineSize = 4000 );
+    Task<GarminActivityDetails> GetActivityDetails (long activityId, int maxChartSize = 2000,
+        int maxPolylineSize = 4000);
 
     /// <summary>
     /// Fetch activity excercise sets
     /// </summary>
-    Task<GarminExcerciseSets> GetActivityExcerciseSets ( long activityId );
+    Task<GarminExcerciseSets> GetActivityExcerciseSets (long activityId);
 
     /// <summary>
     /// Fetch activity weather
     /// </summary>
-    Task<GarminActivityWeather> GetActivityWeather ( long activityId );
+    Task<GarminActivityWeather> GetActivityWeather (long activityId);
 
     /// <summary>
     ///  Fetch activity splits
     /// </summary>
-    Task<GarminActivitySplits> GetActivitySplits ( long activityId );
+    Task<GarminActivitySplits> GetActivitySplits (long activityId);
 
     /// <summary>
     /// Fetch activity HR in timezones
     /// </summary>
-    Task<GarminHrTimeInZones[]> GetActivityHrInTimezones ( long activityId );
+    Task<GarminHrTimeInZones[]> GetActivityHrInTimezones (long activityId);
 
     /// <summary>
     /// Downloads activity in requested format and returns the raw bytes. For
     /// "Original" will return the zip file content, up to user to extract it.
     /// "CSV" will return a csv of the splits.
     /// </summary>
-    Task<byte[]> DownloadActivity ( long activityId, ActivityDownloadFormat format = ActivityDownloadFormat.TCX );
+    Task<byte[]> DownloadActivity (long activityId, ActivityDownloadFormat format = ActivityDownloadFormat.TCX);
 
     /// <summary>
     /// Fetch available activities
     /// </summary>
-    Task<GarminActivity[]> GetActivities ( int start, int limit );
+    Task<GarminActivity[]> GetActivities (int start, int limit);
 
     /// <summary>
     /// Fetch available activities between specific dates
@@ -117,7 +118,7 @@ public interface IGarminConnectClient
     /// (Optional) Type of activity you are searching
     /// Possible values are [cycling, running, swimming, multi_sport, fitness_equipment, hiking, walking, other]
     /// </param>
-    Task<GarminActivity[]> GetActivitiesByDate ( DateTime startDate, DateTime endDate, string activityType = "" );
+    Task<GarminActivity[]> GetActivitiesByDate (DateTime startDate, DateTime endDate, string activityType = "");
 
     /// <summary>
     /// Fetch gear types.
@@ -127,10 +128,10 @@ public interface IGarminConnectClient
     /// <summary>
     /// Fetch user gears.
     /// </summary>
-    Task<GarminGear[]> GetUserGears ( long userId );
+    Task<GarminGear[]> GetUserGears (long userId);
 
     /// <summary>
     /// Fetch activity gears.
     /// </summary>
-    Task<GarminGear[]> GetActivityGears ( long activityId );
+    Task<GarminGear[]> GetActivityGears (long activityId);
 }

--- a/Garmin.Connect/IGarminConnectClient.cs
+++ b/Garmin.Connect/IGarminConnectClient.cs
@@ -6,107 +6,107 @@ namespace Garmin.Connect;
 
 public interface IGarminConnectClient
 {
-    Task<GarminUserPreferences> GetPreferences();
+    Task<GarminUserPreferences> GetPreferences ();
 
-    Task<GarminSocialProfile> GetSocialProfile();
+    Task<GarminSocialProfile> GetSocialProfile ();
 
     /// <summary>
     /// Fetch user settings
     /// </summary>
-    Task<GarminUserSettings> GetUserSettings();
+    Task<GarminUserSettings> GetUserSettings ();
 
     /// <summary>
     /// Fetch available activity data
     /// </summary>
-    Task<GarminStats> GetUserSummary(DateTime date);
+    Task<GarminStats> GetUserSummary ( DateTime date );
 
     /// <summary>
     /// Fetch available sleep data
     /// </summary>
-    Task<GarminSleepData> GetWellnessSleepData(DateTime date);
+    Task<GarminSleepData> GetWellnessSleepData ( DateTime date );
 
     /// <summary>
     /// Fetch available heart rates data
     /// </summary>
-    Task<GarminHr> GetWellnessHeartRates(DateTime date);
+    Task<GarminHr> GetWellnessHeartRates ( DateTime date );
 
     /// <summary>
     /// Fetch available steps data
     /// </summary>
-    Task<GarminStepsData[]> GetWellnessStepsData(DateTime date);
+    Task<GarminStepsData[]> GetWellnessStepsData ( DateTime date );
 
     /// <summary>
     /// Fetch available hydration data
     /// </summary>
-    Task<GarminHydrationData> GetHydrationData(DateTime date);
+    Task<GarminHydrationData> GetHydrationData ( DateTime date );
 
     /// <summary>
     /// Fetch available body composition data (only for date)
     /// </summary>
-    Task<GarminBodyComposition> GetBodyComposition(DateTime startDate, DateTime endDate);
+    Task<GarminBodyComposition> GetBodyComposition ( DateTime startDate, DateTime endDate );
 
     /// <summary>
     /// Fetch personal records by owner display name
     /// </summary>
-    Task<GarminPersonalRecord[]> GetPersonalRecord(string ownerDisplayName);
+    Task<GarminPersonalRecord[]> GetPersonalRecord ( string ownerDisplayName );
 
     /// <summary>
     /// Fetch device last used
     /// </summary>
-    Task<GarminDeviceLastUsed> GetDeviceLastUsed();
+    Task<GarminDeviceLastUsed> GetDeviceLastUsed ();
 
     /// <summary>
     /// Fetch device settings for current device
     /// </summary>
-    Task<GarminDeviceSettings> GetDeviceSettings(long deviceId);
+    Task<GarminDeviceSettings> GetDeviceSettings ( long deviceId );
 
     /// <summary>
     /// Fetch available devices for the current account
     /// </summary>
-    Task<GarminDevice[]> GetDevices();
+    Task<GarminDevice[]> GetDevices ();
 
     /// <summary>
     /// Fetch activity split summaries
     /// </summary>
-    Task<GarminSplitSummary> GetActivitySplitSummaries(long activityId);
+    Task<GarminSplitSummary> GetActivitySplitSummaries ( long activityId );
 
     /// <summary>
     /// Fetch activity details
     /// </summary>
-    Task<GarminActivityDetails> GetActivityDetails(long activityId, int maxChartSize = 2000,
-        int maxPolylineSize = 4000);
+    Task<GarminActivityDetails> GetActivityDetails ( long activityId, int maxChartSize = 2000,
+        int maxPolylineSize = 4000 );
 
     /// <summary>
     /// Fetch activity excercise sets
     /// </summary>
-    Task<GarminExcerciseSets> GetActivityExcerciseSets(long activityId);
+    Task<GarminExcerciseSets> GetActivityExcerciseSets ( long activityId );
 
     /// <summary>
     /// Fetch activity weather
     /// </summary>
-    Task<GarminActivityWeather> GetActivityWeather(long activityId);
+    Task<GarminActivityWeather> GetActivityWeather ( long activityId );
 
     /// <summary>
     ///  Fetch activity splits
     /// </summary>
-    Task<GarminActivitySplits> GetActivitySplits(long activityId);
+    Task<GarminActivitySplits> GetActivitySplits ( long activityId );
 
     /// <summary>
     /// Fetch activity HR in timezones
     /// </summary>
-    Task<GarminHrTimeInZones[]> GetActivityHrInTimezones(long activityId);
+    Task<GarminHrTimeInZones[]> GetActivityHrInTimezones ( long activityId );
 
     /// <summary>
     /// Downloads activity in requested format and returns the raw bytes. For
     /// "Original" will return the zip file content, up to user to extract it.
     /// "CSV" will return a csv of the splits.
     /// </summary>
-    Task<byte[]> DownloadActivity(long activityId, ActivityDownloadFormat format = ActivityDownloadFormat.TCX);
+    Task<byte[]> DownloadActivity ( long activityId, ActivityDownloadFormat format = ActivityDownloadFormat.TCX );
 
     /// <summary>
     /// Fetch available activities
     /// </summary>
-    Task<GarminActivity[]> GetActivities(int start, int limit);
+    Task<GarminActivity[]> GetActivities ( int start, int limit );
 
     /// <summary>
     /// Fetch available activities between specific dates
@@ -117,5 +117,20 @@ public interface IGarminConnectClient
     /// (Optional) Type of activity you are searching
     /// Possible values are [cycling, running, swimming, multi_sport, fitness_equipment, hiking, walking, other]
     /// </param>
-    Task<GarminActivity[]> GetActivitiesByDate(DateTime startDate, DateTime endDate, string activityType = "");
+    Task<GarminActivity[]> GetActivitiesByDate ( DateTime startDate, DateTime endDate, string activityType = "" );
+
+    /// <summary>
+    /// Fetch gear types.
+    /// </summary>
+    Task<GarminGearType[]> GetGearTypes ();
+
+    /// <summary>
+    /// Fetch user gears.
+    /// </summary>
+    Task<GarminGear[]> GetUserGears ( long userId );
+
+    /// <summary>
+    /// Fetch activity gears.
+    /// </summary>
+    Task<GarminGear[]> GetActivityGears ( long activityId );
 }

--- a/Garmin.Connect/Models/GarminGear.cs
+++ b/Garmin.Connect/Models/GarminGear.cs
@@ -1,0 +1,77 @@
+using System;
+using System.Text.Json.Serialization;
+
+using Garmin.Connect.Converters;
+
+namespace Garmin.Connect.Models;
+
+public record GarminGear
+{
+    [JsonPropertyName("uuid")]
+    public string Uuid { get; init; }
+
+    [JsonPropertyName("gearPk")]
+    public int GearPk { get; init; }
+
+    [JsonPropertyName("userProfilePk")]
+    public Int64 UserProfileID { get; init; }
+
+    [JsonPropertyName("gearMakeName")]
+    public string GearMakeName { get; init; }
+
+    [JsonPropertyName("gearModelName")]
+    public string GearModelName { get; init; }
+
+    [JsonPropertyName("gearTypeName")]
+    public string GearTypeName { get; init; }
+
+    [JsonPropertyName("displayName")]
+    public string DisplayName { get; init; }
+
+    [JsonPropertyName("customMakeModel")]
+    public string CustomMakeModel { get; init; }
+
+    [JsonPropertyName("imageNameLarge")]
+    public string ImageNameLarge { get; init; }
+
+    [JsonPropertyName("imageNameMedium")]
+    public string ImageNameMedium { get; init; }
+
+    [JsonPropertyName("imageNameSmall")]
+    public string ImageNameSmall { get; init; }
+
+    [JsonPropertyName("dateBegin")]
+    [JsonConverter(typeof(DateTimeConverter))]
+    public DateTime DateBegin { get; init; }
+
+    [JsonPropertyName("dateEnd")]
+    [JsonConverter(typeof(DateTimeConverter))]
+    public DateTime DateEnd { get; init; }
+
+    [JsonPropertyName("maximumMeters")]
+    public double MaximumMeters { get; init; }
+
+    [JsonPropertyName("notified")]
+    public bool Notified { get; init; }
+
+    [JsonPropertyName("createDate")]
+    public DateTime CreateDate { get; init; }
+
+    [JsonPropertyName("updateDate")]
+    public DateTime UpdateDate { get; init; }
+}
+
+public record GarminGearType
+{
+    [JsonPropertyName("gearTypePk")]
+    public int GearTypePk { get; init; }
+
+    [JsonPropertyName("gearTypeName")]
+    public string GearTypeName { get; init; }
+
+    [JsonPropertyName("createDate")]
+    public DateTime CreateDate { get; init; }
+
+    [JsonPropertyName("updateData")]
+    public DateTime UpdateData { get; init; }
+}

--- a/Garmin.Connect/Models/GarminGear.cs
+++ b/Garmin.Connect/Models/GarminGear.cs
@@ -46,7 +46,7 @@ public record GarminGear
 
     [JsonPropertyName("dateEnd")]
     [JsonConverter(typeof(DateTimeConverter))]
-    public DateTime DateEnd { get; init; }
+    public DateTime? DateEnd { get; init; }
 
     [JsonPropertyName("maximumMeters")]
     public double MaximumMeters { get; init; }
@@ -73,5 +73,5 @@ public record GarminGearType
     public DateTime CreateDate { get; init; }
 
     [JsonPropertyName("updateData")]
-    public DateTime UpdateData { get; init; }
+    public DateTime? UpdateData { get; init; }
 }


### PR DESCRIPTION
- new models: GarminGear, GarminGearType
- new IGarminConnectClient methods: GetGearTypes, GetUserGears, GetActivityGears
- DateTimeConverter: supports "yyyy-MM-dd\\THH:mm:ss.f" format and "null" value as they are used by gears
- GearsTests added

Sorry for the wrong commit description "[fatal: fsync error on 'loose object file': Bad file descriptor]", the correct is: DateTime? instead of stupid handling of "null" at DateTimeConverter