### PR TITLE
Allowing to build for .NET 5.0

### DIFF
--- a/Garmin.Connect/Garmin.Connect.csproj
+++ b/Garmin.Connect/Garmin.Connect.csproj
@@ -2,6 +2,7 @@
 
     <PropertyGroup>
         <TargetFramework>net6.0</TargetFramework>
+        <LangVersion>latest</LangVersion>
     </PropertyGroup>
 
     <PropertyGroup>


### PR DESCRIPTION
.NET 5.0 is useful because .NET 6.0 is not available everywhere. The proposed change avoids "error CS8773: Feature 'file-scoped namespace' is not available in C# 9.0. Please use language version 10.0 or greater"
Please publish NuGet package for .NET 5.0 too.